### PR TITLE
Small bug fix

### DIFF
--- a/lib/threadz/thread_pool.rb
+++ b/lib/threadz/thread_pool.rb
@@ -111,7 +111,7 @@ module Threadz
             @killscore > 0 ? kill_thread : spawn_thread
             @killscore = 0
           end
-          dputs "killscore: #{@killscore}. waiting: #{@queue.num_waiting}.  threads length: #{@worker_threads_count.value}.  min/max: [#{@min_size}, #{@max_size}]"
+          Threadz.dputs "killscore: #{@killscore}. waiting: #{@queue.num_waiting}.  threads length: #{@worker_threads_count.value}.  min/max: [#{@min_size}, #{@max_size}]"
           sleep 0.1
         end
       end


### PR DESCRIPTION
There was a call to #dputs inside of the ThreadPool class. That method is a class method on Threadz but it was being treated as an instance method on ThreadPool. This patch fixes that problem.
